### PR TITLE
[CHORE] adding telemetry producer

### DIFF
--- a/internal/repository/duckdb/migrations/000001_create_schema_tables.down.sql
+++ b/internal/repository/duckdb/migrations/000001_create_schema_tables.down.sql
@@ -1,3 +1,4 @@
 -- Drop tables in correct order (child table first due to foreign key)
 DROP TABLE IF EXISTS schema_attributes;
+DROP TABLE IF EXISTS schema_producers;
 DROP TABLE IF EXISTS telemetry_schemas;

--- a/internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql
+++ b/internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql
@@ -24,3 +24,16 @@ CREATE TABLE IF NOT EXISTS schema_attributes (
     source TEXT,
     FOREIGN KEY (schema_id) REFERENCES telemetry_schemas(schema_id)
 );
+
+CREATE TABLE IF NOT EXISTS schema_producers (
+    schema_id TEXT,
+    producer_id TEXT,
+    name TEXT,
+    namespace TEXT,
+    version TEXT,
+    instance_id TEXT,
+    first_seen TIMESTAMP,
+    last_seen TIMESTAMP,
+    FOREIGN KEY (schema_id) REFERENCES telemetry_schemas(schema_id),
+    PRIMARY KEY (schema_id, producer_id)
+);

--- a/internal/repository/duckdb/telemetry_schema.go
+++ b/internal/repository/duckdb/telemetry_schema.go
@@ -56,6 +56,20 @@ func (r *TelemetrySchemaRepository) RegisterTelemetrySchemas(ctx context.Context
 	}
 	defer attrStmt.Close()
 
+	producerStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO schema_producers (
+			schema_id, producer_id, name, namespace, version, instance_id,
+			first_seen, last_seen
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (schema_id, producer_id) DO UPDATE SET
+			last_seen = excluded.last_seen
+		WHERE excluded.last_seen > schema_producers.last_seen;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare producer insert statement: %w", err)
+	}
+	defer producerStmt.Close()
+
 	for _, schema := range schemas {
 		_, err = schemaStmt.ExecContext(ctx,
 			schema.SchemaID,
@@ -86,6 +100,23 @@ func (r *TelemetrySchemaRepository) RegisterTelemetrySchemas(ctx context.Context
 			)
 			if err != nil {
 				return fmt.Errorf("failed to insert attribute for schema %v: %w", schema.SchemaID, err)
+			}
+		}
+
+		// Insert producers
+		for _, producer := range schema.Producers {
+			_, err = producerStmt.ExecContext(ctx,
+				schema.SchemaID,
+				producer.ProducerID(),
+				producer.Name,
+				producer.Namespace,
+				producer.Version,
+				producer.InstanceID,
+				producer.FirstSeen,
+				producer.LastSeen,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to insert producer for schema %v: %w", schema.SchemaID, err)
 			}
 		}
 	}
@@ -325,5 +356,42 @@ func (r *TelemetrySchemaRepository) GetSchemaByKey(ctx context.Context, schemaKe
 	}
 
 	s.Attributes = attributes
+
+	// Get producers for this schema
+	producerQuery := `
+		SELECT producer_id, name, namespace, version, instance_id,
+			   first_seen, last_seen, source
+		FROM schema_producers
+		WHERE schema_id = ?`
+
+	rows, err = db.QueryContext(ctx, producerQuery, s.SchemaID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query schema producers: %w", err)
+	}
+	defer rows.Close()
+
+	s.Producers = make(map[string]*schema.Producer)
+	for rows.Next() {
+		var producer schema.Producer
+		var producerID string
+		if err := rows.Scan(
+			&producerID,
+			&producer.Name,
+			&producer.Namespace,
+			&producer.Version,
+			&producer.InstanceID,
+			&producer.FirstSeen,
+			&producer.LastSeen,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan producer row: %w", err)
+		}
+
+		s.Producers[producerID] = &producer
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating producer rows: %w", err)
+	}
+
 	return &s, nil
 }

--- a/internal/schema/producer.go
+++ b/internal/schema/producer.go
@@ -1,0 +1,40 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+type Producer struct {
+	Name       string    `json:"name"`
+	Namespace  string    `json:"namespace,omitempty"`
+	Version    string    `json:"version,omitempty"`
+	InstanceID string    `json:"instanceId,omitempty"`
+	FirstSeen  time.Time `json:"firstSeen"`
+	LastSeen   time.Time `json:"lastSeen"`
+}
+
+// ProducerID generates a unique ID for a producer using xxhash
+func (p *Producer) ProducerID() string {
+	parts := []string{
+		p.Name,
+		p.Namespace,
+		p.Version,
+		p.InstanceID,
+	}
+
+	// Filter out empty parts
+	var nonEmptyParts []string
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+
+	h := xxhash.New()
+	h.Write([]byte(strings.Join(nonEmptyParts, "|")))
+	return fmt.Sprintf("%x", h.Sum64())
+}

--- a/internal/schema/telemetry.go
+++ b/internal/schema/telemetry.go
@@ -52,4 +52,6 @@ type Telemetry struct {
 	SeenCount         int               `json:"seenCount"`
 	CreatedAt         time.Time         `json:"createdAt"`
 	UpdatedAt         time.Time         `json:"updatedAt"`
+	// Producers maps producer keys to their information
+	Producers map[string]*Producer `json:"producers"`
 }

--- a/ui/src/components/schema-catalog/TelemetryOverviewPanel.tsx
+++ b/ui/src/components/schema-catalog/TelemetryOverviewPanel.tsx
@@ -153,7 +153,7 @@ export function TelemetryOverviewPanel({ telemetry }: TelemetryOverviewPanelProp
                 <Database className="h-3.5 w-3.5 text-muted-foreground" />
                 <span className="text-sm">Services</span>
               </div>
-              <span className="text-sm font-medium">{1} services</span>
+              <span className="text-sm font-medium">{Object.keys(telemetry.producers).length} services</span>
             </div>
 
             {/* <div>

--- a/ui/src/components/telemetry/telemetry-sources-panel.tsx
+++ b/ui/src/components/telemetry/telemetry-sources-panel.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { X, Search, Server, Clock, Tag, Hash } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import type { Telemetry, TelemetryProducer } from "@/types/telemetry"
+
+interface TelemetryProducersPanelProps {
+  schemaData: Telemetry | null
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function TelemetryProducersPanel({ schemaData, isOpen, onClose }: TelemetryProducersPanelProps) {
+  // State for the sources panel
+  const [searchQuery, setSearchQuery] = useState("")
+  const [filteredSources, setFilteredSources] = useState<any[]>([])
+
+  // Compact date format function
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(date)
+  }
+
+  useEffect(() => {
+    if (schemaData?.producers) {
+      // Add mock data for namespace, firstSeen, and lastSeen
+      const sourcesWithMockData = Object.values(schemaData.producers).map((source: TelemetryProducer) => ({
+        ...source,
+        namespace: source.namespace,
+        firstSeen: source.firstSeen,
+        lastSeen: source.lastSeen,
+      }))
+
+      setFilteredSources(sourcesWithMockData)
+    }
+  }, [schemaData])
+
+  // Reset state when panel is opened
+  useEffect(() => {
+    if (isOpen) {
+      setSearchQuery("")
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (schemaData?.producers) {
+      const sourcesWithMockData = Object.values(schemaData.producers).map((source: TelemetryProducer) => ({
+        ...source,
+        namespace: source.namespace || '',
+        firstSeen: source.firstSeen,
+        lastSeen: source.lastSeen,
+      }))
+
+      const newFilteredSources = sourcesWithMockData?.filter((source: any) => {
+        if (!searchQuery) return true;
+        
+        const name = source.name?.toLowerCase() || '';
+        const namespace = source.namespace?.toLowerCase() || '';
+        const query = searchQuery.toLowerCase();
+        
+        return name.includes(query) || namespace.includes(query);
+      })
+      setFilteredSources(newFilteredSources)
+    }
+  }, [searchQuery, schemaData])
+
+  if (!isOpen) return null
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose()
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-background/10 backdrop-blur-sm" onClick={handleBackdropClick}>
+      <div className="fixed inset-y-0 right-0 w-full max-w-4xl border-l bg-background shadow-lg">
+        <div className="flex h-full flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Server className="h-5 w-5 text-indigo-500" />
+              <h2 className="text-lg font-semibold">Telemetry Producers</h2>
+              <Badge variant="secondary" className="ml-1">
+                {filteredSources?.length || 0}
+              </Badge>
+            </div>
+            <Button variant="ghost" size="icon" onClick={onClose}>
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </div>
+
+          {/* Search */}
+          <div className="border-b px-6 py-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Search producers..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-hidden">
+            <ScrollArea className="h-full">
+              <div className="px-6 py-4">
+                <div className="text-sm text-muted-foreground mb-6">
+                  {filteredSources?.length || 0} producers generating{" "}
+                  <span className="font-mono font-medium text-foreground">{schemaData?.schemaKey}</span> telemetry
+                </div>
+
+                <div className="rounded-lg border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="hover:bg-transparent">
+                        <TableHead className="w-[240px] font-semibold">Name</TableHead>
+                        <TableHead className="w-[140px] font-semibold">Namespace</TableHead>
+                        <TableHead className="w-[120px] font-semibold">Version</TableHead>
+                        <TableHead className="w-[140px] font-semibold">First Seen</TableHead>
+                        <TableHead className="w-[140px] font-semibold">Last Seen</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredSources?.map((source: any) => (
+                        <TableRow key={`${source.name}-${source.namespace}-${source.version}`} className="hover:bg-muted/50">
+                          <TableCell className="py-4">
+                            <div className="flex items-center gap-3">
+                              <Server className="h-4 w-4 text-indigo-500 flex-shrink-0" />
+                              <span className="font-medium">{source.name || 'N/A'}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="py-4">
+                            <div className="flex items-center gap-2">
+                              <span className="font-mono text-sm whitespace-nowrap">{source.namespace || 'N/A'}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="py-4">
+                            <div className="flex items-center gap-2">
+                              <Tag className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                              <Badge variant="outline" className="font-mono">
+                                {source.version ? `v${source.version}` : 'N/A'}
+                              </Badge>
+                            </div>
+                          </TableCell>
+                          <TableCell className="py-4">
+                            <div className="flex items-center gap-2 text-sm">
+                              <Clock className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                              <span className="whitespace-nowrap font-mono">{formatDate(source.firstSeen)}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="py-4">
+                            <div className="flex items-center gap-2 text-sm">
+                              <Clock className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                              <span className="whitespace-nowrap font-mono">{formatDate(source.lastSeen)}</span>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+
+                {filteredSources?.length === 0 && (
+                  <div className="text-center py-12">
+                    <Server className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                    <h3 className="text-lg font-medium mb-2">No producers found</h3>
+                    <p className="text-muted-foreground">
+                      {searchQuery ? "Try adjusting your search terms." : "No telemetry producers are available."}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/routes/data-governance/$telemetryName.tsx
+++ b/ui/src/routes/data-governance/$telemetryName.tsx
@@ -9,14 +9,16 @@ import { useTelemetryDetails } from '@/hooks/use-telemetry-details'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent } from '@/components/ui/card'
 import { SchemaDefinitionView } from '@/components/schema-catalog/SchemaDefinitionView'
+import { TelemetryProducersPanel } from '@/components/telemetry/telemetry-sources-panel'
 
 export const TelemetryDetails = () => {
   const { telemetryName } = useParams({ from: '/data-governance/$telemetryName' })
   const [activeTab, setActiveTab] = useState("schema")
   const { data: telemetry, isLoading, error } = useTelemetryDetails({ telemetryName })
+  const [isProducersPanelOpen, setIsProducersPanelOpen] = useState(false)
 
   const handleViewAllSources = () => {
-    // setIsSourcesPanelOpen(true)
+    setIsProducersPanelOpen(true)
   }
 
   if (isLoading) {
@@ -96,7 +98,7 @@ export const TelemetryDetails = () => {
               onClick={handleViewAllSources}
             >
               <Server className="h-3.5 w-3.5" />
-              {0} Sources
+              {Object.keys(telemetry.producers).length} Sources
             </Button>
 
             {/* View Validation Button */}
@@ -148,7 +150,11 @@ export const TelemetryDetails = () => {
         </TabsContent>
       </Tabs>
 
-
+      <TelemetryProducersPanel
+        schemaData={telemetry}
+        isOpen={isProducersPanelOpen}
+        onClose={() => setIsProducersPanelOpen(false)}
+      />
     </div>
   )
 }

--- a/ui/src/types/telemetry.ts
+++ b/ui/src/types/telemetry.ts
@@ -14,6 +14,13 @@ export enum Status {
 
 export type ViewMode = 'grid' | 'list'
 
+export interface TelemetryProducer {
+  name: string
+  namespace: string
+  firstSeen: string
+  lastSeen: string
+}
+
 export interface Telemetry {
   schemaId: string
   schemaKey: string
@@ -30,6 +37,7 @@ export interface Telemetry {
   createdAt: string
   updatedAt: string
   attributes: Attribute[]
+  producers: Record<string, TelemetryProducer>
 }
 
 export interface Attribute {


### PR DESCRIPTION
This pull request introduces support for tracking schema producers in the telemetry schema repository. The changes include creating a new `schema_producers` table, updating the repository logic to handle producers, and extending the schema extraction process to capture producer information.

### Database Schema Updates:
* Added a new `schema_producers` table to store producer-related information, including `schema_id`, `producer_id`, `name`, `namespace`, `version`, `instance_id`, `first_seen`, and `last_seen`. This table includes a foreign key constraint on `schema_id` and a composite primary key on `schema_id` and `producer_id` (`internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql`, [internal/repository/duckdb/migrations/000001_create_schema_tables.up.sqlR27-R39](diffhunk://#diff-4e8f192b760c2cbb81c78e029290be156ab1677e69b51356de58b21a1691dcf5R27-R39)).
* Updated the corresponding `.down.sql` migration to drop the `schema_producers` table (`internal/repository/duckdb/migrations/000001_create_schema_tables.down.sql`, [internal/repository/duckdb/migrations/000001_create_schema_tables.down.sqlR3](diffhunk://#diff-b38586fad05e0325d0f7fbdc5ed5075e50aa9787ae28605f915ff255f58c35a7R3)).

### Repository Logic Enhancements:
* Modified `RegisterTelemetrySchemas` to insert or update producer information in the `schema_producers` table, ensuring `last_seen` is updated only if the new value is more recent (`internal/repository/duckdb/telemetry_schema.go`, [[1]](diffhunk://#diff-8845412e69149791a55457c75154abc23d431ed5d1307512ee4edce3404bca0bR59-R72) [[2]](diffhunk://#diff-8845412e69149791a55457c75154abc23d431ed5d1307512ee4edce3404bca0bR105-R121).
* Updated `GetSchemaByKey` to retrieve producer data for a schema and populate the `Producers` field in the schema object (`internal/repository/duckdb/telemetry_schema.go`, [internal/repository/duckdb/telemetry_schema.goR359-R395](diffhunk://#diff-8845412e69149791a55457c75154abc23d431ed5d1307512ee4edce3404bca0bR359-R395)).

### Schema Extraction Updates:
* Extended the `ExtractFromMetrics` function to capture producer details from resource attributes, such as `service.name`, `service.namespace`, `service.version`, and `service.instance.id`. Producers with a valid `name` are added to the telemetry object (`internal/schema/schema_extractor.go`, [[1]](diffhunk://#diff-3f30e0a8d734a254e35981f36ef58d0a6b838a8a866a6464d3b9ff570b7bdc9dR96-R115) [[2]](diffhunk://#diff-3f30e0a8d734a254e35981f36ef58d0a6b838a8a866a6464d3b9ff570b7bdc9dR124-R128).

### New Data Structure:
* Introduced a `Producer` struct in `internal/schema/producer.go` to represent producer information, including a method to generate a unique `ProducerID` using `xxhash` (`internal/schema/producer.go`, [internal/schema/producer.goR1-R40](diffhunk://#diff-afa195a1443ee9f9bedf2170f79b7ee8a3efbf03e18a51973bb1408b75a9aa62R1-R40)).

### Telemetry Struct Update:
* Added a `Producers` field to the `Telemetry` struct to map producer IDs to their corresponding `Producer` objects (`internal/schema/telemetry.go`, [internal/schema/telemetry.goR55-R56](diffhunk://#diff-28f5d500d7a3293c2c722456c2043e83b58f5796ee3ff9dbb3a2de8f72f750fcR55-R56)).